### PR TITLE
Implement SeekableByteChannel for URL connections

### DIFF
--- a/src/main/java/org/magicdgs/http/jsr203/HttpUtils.java
+++ b/src/main/java/org/magicdgs/http/jsr203/HttpUtils.java
@@ -1,5 +1,8 @@
 package org.magicdgs.http.jsr203;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.net.HttpURLConnection;
 import java.net.URLConnection;
 
@@ -9,6 +12,15 @@ import java.net.URLConnection;
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
 public final class HttpUtils {
+
+    // key for 'Range' request
+    private static final String RANGE_REQUEST_PROPERTY_KEY = "Range";
+    // value for 'Range' request: START + POSITION + SEPARATOR (+ END)
+    private static final String RANGE_REQUEST_PROPERTY_VALUE_START = "bytes=";
+    private static final String RANGE_REQUEST_PROPERTY_VALUE_SEPARATOR = "-";
+
+    // logger for HttpUtils
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpUtils.class);
 
     // utility class - cannot be instantiated
     private HttpUtils() {}
@@ -23,4 +35,36 @@ public final class HttpUtils {
             ((HttpURLConnection) connection).disconnect();
         }
     }
+
+    /**
+     * Request a range of bytes for a {@link URLConnection}.
+     *
+     * @param connection the connection to request the range.
+     * @param start      positive byte number to start the request.
+     * @param end        positive byte number to end the request; {@code -1} if no bounded.
+     *
+     * @throws IllegalStateException    if the connection is already connected.
+     * @throws IllegalArgumentException if the request is invalid.
+     */
+    public static void setRangeRequest(final URLConnection connection, final long start,
+            final long end) {
+        // setting the request range
+        String request = RANGE_REQUEST_PROPERTY_VALUE_START
+                + start
+                + RANGE_REQUEST_PROPERTY_VALUE_SEPARATOR;
+        // include end bound
+        if (end != -1) {
+            request += end;
+        }
+
+        // invalid request params should throw
+        if (start < 0 || end < -1 || (end != -1 && end < start)) {
+            throw new IllegalArgumentException("Invalid request: " + request);
+        }
+
+        LOGGER.debug("Request '{}' {} for {}", RANGE_REQUEST_PROPERTY_KEY, request, connection);
+        // set the range if the position is different from 0
+        connection.setRequestProperty(RANGE_REQUEST_PROPERTY_KEY, request);
+    }
+
 }

--- a/src/main/java/org/magicdgs/http/jsr203/HttpUtils.java
+++ b/src/main/java/org/magicdgs/http/jsr203/HttpUtils.java
@@ -1,0 +1,26 @@
+package org.magicdgs.http.jsr203;
+
+import java.net.HttpURLConnection;
+import java.net.URLConnection;
+
+/**
+ * Utility classes for working with HTTP/S connections and URLs.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public final class HttpUtils {
+
+    // utility class - cannot be instantiated
+    private HttpUtils() {}
+
+    /**
+     * Disconnects the {@link URLConnection} if it is an instance of {@link HttpURLConnection}.
+     *
+     * @param connection the connection to be disconnected.
+     */
+    public static void disconnect(final URLConnection connection) {
+        if (connection instanceof HttpURLConnection) {
+            ((HttpURLConnection) connection).disconnect();
+        }
+    }
+}

--- a/src/main/java/org/magicdgs/http/jsr203/URLSeekableByteChannel.java
+++ b/src/main/java/org/magicdgs/http/jsr203/URLSeekableByteChannel.java
@@ -1,0 +1,156 @@
+package org.magicdgs.http.jsr203;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.NonWritableChannelException;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.SeekableByteChannel;
+
+/**
+ * Implementation for a {@link SeekableByteChannel} for {@link URL} open as a connection.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ * @implNote this seekable byte channel is read-only..
+ */
+class URLSeekableByteChannel implements SeekableByteChannel {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    // url and proxy for the file
+    private final URL url;
+
+    // current position of the SeekableByteChannel
+    private long position = 0;
+
+    // the size of the whole file (-1 is not initialized)
+    private long size = -1;
+
+    private ReadableByteChannel channel = null;
+    private InputStream backedStream = null;
+
+
+    URLSeekableByteChannel(final URL url) throws IOException {
+        this.url = url;
+        // and instantiate the stream/channel at position 0
+        instantiateChannel(this.position);
+    }
+
+    @Override
+    public int read(final ByteBuffer dst) throws IOException {
+        final int read = channel.read(dst);
+        this.position += read;
+        return read;
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        throw new NonWritableChannelException();
+    }
+
+    @Override
+    public long position() throws IOException {
+        if (!isOpen()) {
+            throw new ClosedChannelException();
+        }
+        return position;
+    }
+
+    @Override
+    public URLSeekableByteChannel position(long newPosition) throws IOException {
+        if (newPosition < 0) {
+            throw new IllegalArgumentException("Cannot seek a negative position");
+        }
+        if (!isOpen()) {
+            throw new ClosedChannelException();
+        }
+
+        if (this.position < newPosition) {
+            // if the current position is before, do not open a new connection
+            // but skip the bytes until the new position
+            final long bytesToSkip = newPosition - this.position;
+            backedStream.skip(bytesToSkip);
+        } else if (this.position > newPosition) {
+            // in this case, we require to re-instantiate the channel
+            // opening at the new position - and closing the previous
+            close();
+            instantiateChannel(newPosition);
+        }
+
+        // updates to the new position
+        this.position = newPosition;
+
+        return this;
+    }
+
+    @Override
+    public long size() throws IOException {
+        if (!isOpen()) {
+            throw new ClosedChannelException();
+        }
+        if (size == -1) {
+            final URLConnection connection = url.openConnection();
+            connection.connect();
+            // try block for always disconnect the connection
+            try {
+                size = connection.getContentLengthLong();
+                // if the size is still -1, it means that it is unavailable
+                if (size == -1) {
+                    throw new IOException("Unable to retrieve content length for " + url);
+                }
+            } finally {
+                // disconnect if possible
+                disconnect(connection);
+            }
+        }
+        return size;
+    }
+
+    @Override
+    public SeekableByteChannel truncate(long size) throws IOException {
+        throw new NonWritableChannelException();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return channel.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        // this should close also the backed stream
+        channel.close();
+    }
+
+    // open a readable byte channel for the requrested position
+    private void instantiateChannel(final long position) throws IOException {
+        final URLConnection connection = url.openConnection();
+        if (position > 0) {
+            logger.debug("Setting Range to {}", position);
+            // set the range if the position is different from 0
+            connection.setRequestProperty("Range", String.format("bytes=%s-", position));
+        }
+        // get the channel from the backed stream
+        backedStream = connection.getInputStream();
+        channel = Channels.newChannel(backedStream);
+    }
+
+    /**
+     * Disconnects the {@link URLConnection} if it is an instance of {@link HttpURLConnection}.
+     *
+     * @param connection the connection to be disconnected.
+     */
+    private static void disconnect(final URLConnection connection) {
+        if (connection instanceof HttpURLConnection) {
+            ((HttpURLConnection) connection).disconnect();
+        }
+    }
+}

--- a/src/main/java/org/magicdgs/http/jsr203/URLSeekableByteChannel.java
+++ b/src/main/java/org/magicdgs/http/jsr203/URLSeekableByteChannel.java
@@ -25,12 +25,6 @@ import java.nio.channels.SeekableByteChannel;
  */
 class URLSeekableByteChannel implements SeekableByteChannel {
 
-    // key for 'Range' request
-    private static final String RANGE_REQUEST_PROPERTY_KEY = "Range";
-    // value for 'Range' request: START + POSITION + SEPARATOR (+ END)
-    private static final String RANGE_REQUEST_PROPERTY_VALUE_START = "bytes=";
-    private static final String RANGE_REQUEST_PROPERTY_VALUE_SEPARATOR = "-";
-
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     // url and proxy for the file
@@ -144,12 +138,7 @@ class URLSeekableByteChannel implements SeekableByteChannel {
     private synchronized void instantiateChannel(final long position) throws IOException {
         final URLConnection connection = url.openConnection();
         if (position > 0) {
-            final String request = RANGE_REQUEST_PROPERTY_VALUE_START
-                    + position
-                    + RANGE_REQUEST_PROPERTY_VALUE_SEPARATOR;
-            logger.debug("Request '{}' {}", RANGE_REQUEST_PROPERTY_KEY, request);
-            // set the range if the position is different from 0
-            connection.setRequestProperty(RANGE_REQUEST_PROPERTY_KEY, request);
+            HttpUtils.setRangeRequest(connection, position, -1);
         }
         // get the channel from the backed stream
         backedStream = connection.getInputStream();

--- a/src/main/java/org/magicdgs/http/jsr203/URLSeekableByteChannel.java
+++ b/src/main/java/org/magicdgs/http/jsr203/URLSeekableByteChannel.java
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.ByteBuffer;

--- a/src/test/java/org/magicdgs/http/jsr203/BaseTest.java
+++ b/src/test/java/org/magicdgs/http/jsr203/BaseTest.java
@@ -1,9 +1,12 @@
 package org.magicdgs.http.jsr203;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Path;
 
 /**
  * Base test class with useful methods.
@@ -19,33 +22,64 @@ public class BaseTest {
     private static final String DOCS_BASE_PATH = "docs/";
 
     /**
-     * Gets the URL for a file in the project GitHub-pages.
+     * Gets the full URL name for a file in the project's GitHub-pages.
      *
-     * <p>Calling this method with the same file name as in {@link #getPathFromLocalDocsFile(String)}
+     * <p>Calling this method with the same file name as in {@link #getLocalDocsFullPathName(String)}
      * retrieves the equivalent file in the GitHub-pages URL.
      *
-     * @param fileName the name of the file (including intermediate directories).
+     * @param baseName the base name of the file (including intermediate directories).
      *
-     * @return URL string in GitHub-pages.
+     * @return full URL string in GitHub-pages.
      */
-    public static String getGithubPagesFileUrl(final String fileName) {
-        return GITHUP_PAGES_BASE_URL + fileName;
+    public static String getGithubPagesFullUrlName(final String baseName) {
+        return GITHUP_PAGES_BASE_URL + baseName;
     }
 
     /**
-     * Gets the path for a file in docs directory.
+     * Gets the URL for a file in the project GitHub-pages.
      *
-     * <p>Calling this method with the same file name as in {@link #getGithubPagesFileUrl(String)}
+     * @param baseName the base name of the file (including intermediate directories).
+     *
+     * @return URL string in GitHub-pages.
+     *
+     * @throws AssertionError if the URL is malformed (unexpected).
+     * @see #getGithubPagesFileUrl(String)
+     */
+    public static URL getGithubPagesFileUrl(final String baseName) {
+        try {
+            return new URL(getGithubPagesFullUrlName(baseName));
+        } catch (MalformedURLException e) {
+            throw new AssertionError("Unexpected error for GitHub file " + baseName, e);
+        }
+    }
+
+    /**
+     * Gets the full path name for a file in docs directory.
+     *
+     * <p>Calling this method with the same file name as in {@link #getGithubPagesFullUrlName(String)}
      * retrieves the equivalent file in the local file system.
      *
-     * @param fileName the name of the file (including intermediate directories).
+     * @param baseName the base name of the file (including intermediate directories).
      *
      * @return path in the local file system.
      */
-    public static String getPathFromLocalDocsFile(final String fileName) {
-        return DOCS_BASE_PATH + fileName;
+    public static String getLocalDocsFullPathName(final String baseName) {
+        return DOCS_BASE_PATH + baseName;
     }
 
+    /**
+     * Gets the Path for a file in docs directory.
+     *
+     * @param baseName the base name of the file (including intermediate directories).
+     *
+     * @return path in the local file system.
+     *
+     * @see #getLocalDocsFullPathName(String)
+     */
+    public static Path getLocalDocsFilePath(final String baseName) {
+        final Path path = new File(getLocalDocsFullPathName(baseName)).toPath();
+        return path;
+    }
 
     /**
      * Read all bytes from a provided HTTP/S {@link URL}.

--- a/src/test/java/org/magicdgs/http/jsr203/GitHubResourcesIntegrationTest.java
+++ b/src/test/java/org/magicdgs/http/jsr203/GitHubResourcesIntegrationTest.java
@@ -31,8 +31,8 @@ public class GitHubResourcesIntegrationTest extends BaseTest {
 
     @Test(dataProvider = "getDocsFilesForTesting")
     public void testGitHubResourcesExists(final String fileName) throws Exception {
-        final URI uri = new URI(getGithubPagesFileUrl(fileName));
-        final HttpURLConnection connection = (HttpURLConnection) uri.toURL().openConnection();
+        final HttpURLConnection connection = (HttpURLConnection)
+                getGithubPagesFileUrl(fileName).openConnection();
         try {
             connection.setRequestMethod("GET");
             connection.connect();
@@ -44,18 +44,15 @@ public class GitHubResourcesIntegrationTest extends BaseTest {
 
     @Test(dataProvider = "getDocsFilesForTesting")
     public void testLocalDocsResourcesExists(final String fileName) throws Exception {
-        Assert.assertTrue(new File(getPathFromLocalDocsFile(fileName)).exists());
+        Assert.assertTrue(Files.exists(getLocalDocsFilePath(fileName)));
     }
 
     @Test(dataProvider = "getDocsFilesForTesting")
     public void testGithubAndDocsResourcesAreEqual(final String fileName) throws Exception {
         // 1. read the local file
-        final Path localFile = new File(getPathFromLocalDocsFile(fileName)).toPath();
-        final byte[] local = Files.readAllBytes(localFile);
-
+        final byte[] local = Files.readAllBytes(getLocalDocsFilePath(fileName));
         // 2. read the GitHub-pages file
-        final URL githubUrl = new URI(getGithubPagesFileUrl(fileName)).toURL();
-        final byte[] github = readAllBytes(githubUrl);
+        final byte[] github = readAllBytes(getGithubPagesFileUrl(fileName));
 
         // assert that the same bytes were read
         Assert.assertEquals(github, local);

--- a/src/test/java/org/magicdgs/http/jsr203/HttpUtilsUnitTest.java
+++ b/src/test/java/org/magicdgs/http/jsr203/HttpUtilsUnitTest.java
@@ -1,0 +1,38 @@
+package org.magicdgs.http.jsr203;
+
+import org.mockito.Mockito;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.net.URLConnection;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class HttpUtilsUnitTest extends BaseTest {
+
+    @DataProvider
+    public Object[][] illegalArgumentsForRangeRequest() throws Exception {
+        // create a Mocked URL connection that throws an assertion error when
+        // the setRequestProperty is set
+        final URLConnection mockedConnection = Mockito.mock(URLConnection.class);
+        Mockito.doThrow(new AssertionError("Called setRequestProperty")).when(mockedConnection)
+                .setRequestProperty(Mockito.anyString(), Mockito.anyString());
+
+        return new Object[][] {
+                // invalid start
+                {mockedConnection, -1, 10},
+                // invalid end
+                {mockedConnection, 10, -2},
+                // reverse request
+                {mockedConnection, 100, 10}
+        };
+    }
+
+    @Test(dataProvider = "illegalArgumentsForRangeRequest", expectedExceptions = IllegalArgumentException.class)
+    public void testSetRangeRequestIllegalArguments(final URLConnection connection, final int start, final int end)
+            throws Exception {
+        HttpUtils.setRangeRequest(connection, start, end);
+    }
+
+}

--- a/src/test/java/org/magicdgs/http/jsr203/URLSeekableByteChannelUnitTest.java
+++ b/src/test/java/org/magicdgs/http/jsr203/URLSeekableByteChannelUnitTest.java
@@ -137,9 +137,6 @@ public class URLSeekableByteChannelUnitTest extends BaseTest {
                     // first position and then come back to 0
                     actual.position(position).position(0),
                     expected);
-
-            // assert that the size is the same after seek
-            Assert.assertEquals(actual.size(), expected.size());
         }
     }
 
@@ -152,9 +149,6 @@ public class URLSeekableByteChannelUnitTest extends BaseTest {
                     // seek twice to the same position is equal to seek only once
                     actual.position(position).position(position),
                     expected.position(position));
-
-            // assert that the size is the same after seek
-            Assert.assertEquals(actual.size(), expected.size());
         }
     }
 
@@ -167,8 +161,6 @@ public class URLSeekableByteChannelUnitTest extends BaseTest {
                     // seek first to 10 bytes more, and then to the requested position
                     actual.position(position + 10).position(position),
                     expected.position(position));
-
-
         }
     }
 

--- a/src/test/java/org/magicdgs/http/jsr203/URLSeekableByteChannelUnitTest.java
+++ b/src/test/java/org/magicdgs/http/jsr203/URLSeekableByteChannelUnitTest.java
@@ -1,0 +1,194 @@
+package org.magicdgs.http.jsr203;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.NonWritableChannelException;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class URLSeekableByteChannelUnitTest extends BaseTest {
+
+    // helper method to get the GitHub pages as an URL object
+    private static URL getGithubPagesUrl(final String fileName) {
+        try {
+            return new URL(getGithubPagesFileUrl(fileName));
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Should not happen", e);
+        }
+    }
+
+    // helper method to get teh Docs files as an URL object
+    private static Path getDocsPath(final String fileName) {
+        return new File(getPathFromLocalDocsFile(fileName)).toPath();
+    }
+
+
+    @Test(expectedExceptions = FileNotFoundException.class)
+    public void testNonExistentUrl() throws Exception {
+        new URLSeekableByteChannel(getGithubPagesUrl("not_existent.txt"));
+    }
+
+    @Test
+    public void testUnsupportedMethods() throws Exception {
+        try (final URLSeekableByteChannel channel =
+                new URLSeekableByteChannel(getGithubPagesUrl("file1.txt"))) {
+            // cannot write
+            Assert.assertThrows(NonWritableChannelException.class,
+                    () -> channel.write(ByteBuffer.allocate(10)));
+            // cannot truncate
+            Assert.assertThrows(NonWritableChannelException.class, () -> channel.truncate(10));
+        }
+    }
+
+    @Test(dataProvider = "getDocsFilesForTesting", dataProviderClass = GitHubResourcesIntegrationTest.class)
+    public void testSizeFromResources(final String fileName) throws Exception {
+        final URL urlFile = getGithubPagesUrl(fileName);
+        final Path localFile = getDocsPath(fileName);
+        try (final URLSeekableByteChannel urlChannel = new URLSeekableByteChannel(urlFile);
+                final SeekableByteChannel localChannel = Files.newByteChannel(localFile,
+                        StandardOpenOption.READ)) {
+            Assert.assertEquals(urlChannel.size(), localChannel.size());
+        }
+    }
+
+    @Test
+    public void testGetPosition() throws Exception {
+        // open channel
+        try (final URLSeekableByteChannel channel = new URLSeekableByteChannel(
+                getGithubPagesUrl("file1.txt"))) {
+            int currentPosition = 0;
+            Assert.assertEquals(channel.position(), currentPosition);
+            final int bufferSize = Math.round(channel.size() / 10f);
+            final ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
+            for (int i = bufferSize; i <= channel.size(); i += bufferSize) {
+                channel.read(buffer);
+                Assert.assertEquals(channel.position(), i);
+                buffer.rewind();
+            }
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testIllegalPosition() throws Exception {
+        new URLSeekableByteChannel(getGithubPagesUrl("file1.txt")).position(-1);
+    }
+
+    @DataProvider
+    public Iterator<Object[]> seekData() {
+        return Stream.of(GitHubResourcesIntegrationTest.getDocsFilesForTesting())
+                .map(data -> (String) data[0]).map(fileName ->
+                        new Object[] {
+                                getGithubPagesUrl(fileName),
+                                10,
+                                getDocsPath(fileName)
+                        }).iterator();
+    }
+
+    @Test(dataProvider = "seekData")
+    public void testSeekBeforeRead(final URL testUrl, final long position, final Path localFile)
+            throws Exception {
+        try (final URLSeekableByteChannel actual = new URLSeekableByteChannel(testUrl);
+                final SeekableByteChannel expected = Files.newByteChannel(localFile)) {
+            testReadSize((int) expected.size(),
+                    actual.position(position),
+                    expected.position(position));
+        }
+    }
+
+    @Test(dataProvider = "seekData")
+    public void testSeekToBeginning(final URL testUrl, final long position, final Path localFile)
+            throws Exception {
+        try (final URLSeekableByteChannel actual = new URLSeekableByteChannel(testUrl);
+                final SeekableByteChannel expected = Files.newByteChannel(localFile)) {
+            testReadSize((int) expected.size(),
+                    // first position and then come back to 0
+                    actual.position(position).position(0),
+                    expected);
+
+            // assert that the size is the same after seek
+            Assert.assertEquals(actual.size(), expected.size());
+        }
+    }
+
+    @Test(dataProvider = "seekData")
+    public void testSeekToSamePosition(final URL testUrl, final long position, final Path localFile)
+            throws Exception {
+        try (final URLSeekableByteChannel actual = new URLSeekableByteChannel(testUrl);
+                final SeekableByteChannel expected = Files.newByteChannel(localFile)) {
+            testReadSize((int) expected.size(),
+                    // seek twice to the same position is equal to seek only once
+                    actual.position(position).position(position),
+                    expected.position(position));
+
+            // assert that the size is the same after seek
+            Assert.assertEquals(actual.size(), expected.size());
+        }
+    }
+
+    @Test(dataProvider = "seekData")
+    public void testSeekShouldReopen(final URL testUrl, final long position, final Path localFile)
+            throws Exception {
+        try (final URLSeekableByteChannel actual = new URLSeekableByteChannel(testUrl);
+                final SeekableByteChannel expected = Files.newByteChannel(localFile)) {
+            testReadSize((int) expected.size(),
+                    // seek first to 10 bytes more, and then to the requested position
+                    actual.position(position + 10).position(position),
+                    expected.position(position));
+
+            // assert that the size is the same after seek
+            Assert.assertEquals(actual.size(), expected.size());
+        }
+    }
+
+    private static void testReadSize(final int size,
+            final URLSeekableByteChannel actual, final SeekableByteChannel expected)
+            throws Exception {
+        final ByteBuffer expectedBuffer = ByteBuffer.allocate(size);
+        final ByteBuffer actualBuffer = ByteBuffer.allocate(size);
+        Assert.assertEquals(
+                // seek to position and then to the beginning of the file again
+                actual.read(expectedBuffer),
+                expected.read(actualBuffer),
+                "different number of bytes read");
+        expectedBuffer.rewind();
+        actualBuffer.rewind();
+        Assert.assertEquals(expectedBuffer.array(), actualBuffer.array(),
+                "different byte[] after read");
+    }
+
+    @Test
+    public void testClose() throws Exception {
+        // open channel
+        final URLSeekableByteChannel channel =
+                new URLSeekableByteChannel(getGithubPagesUrl("file1.txt"));
+        Assert.assertTrue(channel.isOpen());
+        // close channel
+        channel.close();
+        Assert.assertFalse(channel.isOpen());
+
+        // assert that several methods thrown with the corresponding exception
+        // 1. position
+        Assert.assertThrows(ClosedChannelException.class, () -> channel.position());
+        Assert.assertThrows(ClosedChannelException.class, () -> channel.position(10));
+        // 2. size
+        Assert.assertThrows(ClosedChannelException.class, () -> channel.size());
+        // 3. read
+        Assert.assertThrows(ClosedChannelException.class,
+                () -> channel.read(ByteBuffer.allocate(1)));
+    }
+}


### PR DESCRIPTION
Helper class implementing SeekableByteChannel to be used in the provided to retrieve it from an HTTP/S path.

The implementation allows random access in several ways:

* Seek to byte 0 (beginning of the file) re-opens the connection as a stream
* Seek to a downstream byte skip bytes from the stream
* Seek to an upstream byte re-opens the connection as a stream using the
  "Range" request

Note: the URLSeekableByteChannel is only-read