### PR TITLE
Implement simple HttpFileSystem for each authority

### DIFF
--- a/src/main/java/org/magicdgs/http/jsr203/HttpFileSystem.java
+++ b/src/main/java/org/magicdgs/http/jsr203/HttpFileSystem.java
@@ -39,10 +39,7 @@ final class HttpFileSystem extends FileSystem {
      */
     HttpFileSystem(final HttpAbstractFileSystemProvider provider, final String authority) {
         this.provider = Utils.nonNull(provider, () -> "null provider");
-        if (authority == null) {
-            throw new NullPointerException("Null authority");
-        }
-        this.authority = authority;
+        this.authority = Utils.nonNull(authority, () -> "null authority");
     }
 
     @Override
@@ -61,12 +58,13 @@ final class HttpFileSystem extends FileSystem {
 
     @Override
     public void close() {
-        // TODO - this could remove the instance from the provider and let the JVM clean up
+        // TODO - this should remove the fs from the list in the provider object (https://github.com/magicDGS/jsr203-http/issues/26)
         logger.warn("{} is always open (do not close)", this.getClass());
     }
 
     @Override
     public boolean isOpen() {
+        // TODO - this should check if the fs is in the list stored in the provider object (https://github.com/magicDGS/jsr203-http/issues/26)
         return true;
     }
 
@@ -108,7 +106,8 @@ final class HttpFileSystem extends FileSystem {
 
     @Override
     public Path getPath(final String first, final String... more) {
-        final String path = first + String.join(getSeparator(), more);
+        final String path = Utils.nonNull(first, () -> "null first")
+                + String.join(getSeparator(), Utils.nonNull(more, () -> "null more"));
 
         if (!path.isEmpty() && !path.startsWith(getSeparator())) {
             throw new InvalidPathException(path, "Relative paths are not supported", 0);

--- a/src/main/java/org/magicdgs/http/jsr203/HttpFileSystem.java
+++ b/src/main/java/org/magicdgs/http/jsr203/HttpFileSystem.java
@@ -34,7 +34,7 @@ final class HttpFileSystem extends FileSystem {
     /**
      * Construct a new FileSystem.
      *
-     * @param provider non {@code null} provider that generated this HTTP/S File System.
+     * @param provider  non {@code null} provider that generated this HTTP/S File System.
      * @param authority non {@code null} authority for this HTTP/S File System.
      */
     HttpFileSystem(final HttpAbstractFileSystemProvider provider, final String authority) {
@@ -150,7 +150,8 @@ final class HttpFileSystem extends FileSystem {
             return true;
         } else if (other instanceof HttpFileSystem) {
             final HttpFileSystem ofs = (HttpFileSystem) other;
-            return provider() == ofs.provider() && getAuthority().equalsIgnoreCase(ofs.getAuthority());
+            return provider() == ofs.provider() && getAuthority()
+                    .equalsIgnoreCase(ofs.getAuthority());
         }
         return false;
     }

--- a/src/main/java/org/magicdgs/http/jsr203/HttpFileSystem.java
+++ b/src/main/java/org/magicdgs/http/jsr203/HttpFileSystem.java
@@ -1,13 +1,20 @@
 package org.magicdgs.http.jsr203;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.FileStore;
 import java.nio.file.FileSystem;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.WatchService;
 import java.nio.file.attribute.UserPrincipalLookupService;
 import java.nio.file.spi.FileSystemProvider;
+import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -17,20 +24,25 @@ import java.util.Set;
  */
 final class HttpFileSystem extends FileSystem {
 
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
     private final HttpAbstractFileSystemProvider provider;
 
-    // TODO - remove this constructor (https://github.com/magicDGS/jsr203-http/issues/17)
-    HttpFileSystem() {
-        this.provider = null;
-    }
+    // authority for this FileSystem
+    private final String authority;
 
     /**
      * Construct a new FileSystem.
      *
      * @param provider non {@code null} provider that generated this HTTP/S File System.
+     * @param authority non {@code null} authority for this HTTP/S File System.
      */
-    HttpFileSystem(final HttpAbstractFileSystemProvider provider) {
+    HttpFileSystem(final HttpAbstractFileSystemProvider provider, final String authority) {
         this.provider = Utils.nonNull(provider, () -> "null provider");
+        if (authority == null) {
+            throw new NullPointerException("Null authority");
+        }
+        this.authority = authority;
     }
 
     @Override
@@ -38,14 +50,24 @@ final class HttpFileSystem extends FileSystem {
         return provider;
     }
 
+    /**
+     * Gets the authority for this File System.
+     *
+     * @return the authority for this File System.
+     */
+    public String getAuthority() {
+        return authority;
+    }
+
     @Override
     public void close() {
-        throw new UnsupportedOperationException("Not implemented");
+        // TODO - this could remove the instance from the provider and let the JVM clean up
+        logger.warn("{} is always open (do not close)", this.getClass());
     }
 
     @Override
     public boolean isOpen() {
-        throw new UnsupportedOperationException("Not implemented");
+        return true;
     }
 
     /**
@@ -58,14 +80,20 @@ final class HttpFileSystem extends FileSystem {
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@link HttpUtils#HTTP_PATH_SEPARATOR_STRING}.
+     */
     @Override
     public String getSeparator() {
-        throw new UnsupportedOperationException("Not implemented");
+        return HttpUtils.HTTP_PATH_SEPARATOR_STRING;
     }
 
     @Override
     public Iterable<Path> getRootDirectories() {
-        throw new UnsupportedOperationException("Not implemented");
+        // the root directory does not have the slash
+        return Collections.singleton(new HttpPath(this, "", null, null));
     }
 
     @Override
@@ -80,7 +108,20 @@ final class HttpFileSystem extends FileSystem {
 
     @Override
     public Path getPath(final String first, final String... more) {
-        throw new UnsupportedOperationException("Not implemented");
+        final String path = first + String.join(getSeparator(), more);
+
+        if (!path.isEmpty() && !path.startsWith(getSeparator())) {
+            throw new InvalidPathException(path, "Relative paths are not supported", 0);
+        }
+
+        try {
+            // handle the Path with the URI to separate Path query and fragment
+            // in addition, it checks for errors in the encoding (e.g., null chars)
+            final URI uri = new URI(path);
+            return new HttpPath(this, uri.getPath(), uri.getQuery(), uri.getFragment());
+        } catch (URISyntaxException e) {
+            throw new InvalidPathException(e.getInput(), e.getReason(), e.getIndex());
+        }
     }
 
     @Override
@@ -96,5 +137,26 @@ final class HttpFileSystem extends FileSystem {
     @Override
     public WatchService newWatchService() throws IOException {
         throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s[%s]@%s", this.getClass().getSimpleName(), provider, hashCode());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        } else if (other instanceof HttpFileSystem) {
+            final HttpFileSystem ofs = (HttpFileSystem) other;
+            return provider() == ofs.provider() && getAuthority().equalsIgnoreCase(ofs.getAuthority());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * provider.hashCode() + getAuthority().toLowerCase().hashCode();
     }
 }

--- a/src/main/java/org/magicdgs/http/jsr203/HttpPath.java
+++ b/src/main/java/org/magicdgs/http/jsr203/HttpPath.java
@@ -6,8 +6,7 @@ import java.io.IOError;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.FileSystem;
+import java.nio.file.InvalidPathException;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
@@ -50,9 +49,6 @@ final class HttpPath implements Path {
     // file system (indicates the scheme - HTTP or HTTPS)
     private final HttpFileSystem fs;
 
-    // authority part for the URL
-    private final String authority;
-
     // path - similar to other implementation of Path
     private final byte[] normalizedPath;
 
@@ -65,18 +61,16 @@ final class HttpPath implements Path {
      * Internal constructor.
      *
      * @param fs             file system. Shouldn't be {@code null}.
-     * @param authority      authority. Shouldn't be {@code null}.
      * @param query          query. May be {@code null}.
      * @param reference      reference. May be {@code null}.
      * @param normalizedPath normalized path (as a byte array). Shouldn't be {@code null}.
      *
      * @implNote does not perform any check for efficiency.
      */
-    private HttpPath(final HttpFileSystem fs, final String authority,
+    private HttpPath(final HttpFileSystem fs,
             final String query, final String reference,
             final byte... normalizedPath) {
         this.fs = fs;
-        this.authority = authority;
 
         // optional query and reference components (may be null)
         this.query = query;
@@ -87,46 +81,19 @@ final class HttpPath implements Path {
     }
 
     /**
-     * URI constructor.
+     * Creates a new Path in the provided {@link HttpFileSystem}, with optional query and reference.
      *
-     * @param uri HTTP/S URI.
-     * @param fs  file system used to create the path.
+     * @param fs file system representing the base URL (scheme and authority).
+     * @param path path component for the URL (required).
+     * @param query query  component for the URL (optional).
+     * @param reference reference component for the URL (optional).
      */
-    HttpPath(final URI uri, final HttpFileSystem fs) {
-        this(checkScheme(fs, uri.getScheme()),
-                Utils.nonNull(uri.getAuthority(), () -> "URI without authority"),
-                uri.getQuery(),
-                uri.getFragment(),
-                getNormalizedPathBytes(uri.getPath()));
-    }
-
-    /**
-     * URL constructor.
-     *
-     * @param url HTTP/S URL.
-     * @param fs  file system used to create the path.
-     */
-    HttpPath(final URL url, final HttpFileSystem fs) {
-        this(checkScheme(fs, url.getProtocol()),
-                Utils.nonNull(url.getAuthority(), () -> "URL without authority"),
-                url.getQuery(),
-                url.getRef(),
-                getNormalizedPathBytes(url.getPath()));
-    }
-
-    // helper method to share between constructors
-    private static HttpFileSystem checkScheme(final HttpFileSystem fs, String scheme) {
-        // second check the scheme
-        if (!fs.provider().getScheme().equalsIgnoreCase(scheme)) {
-            throw new IllegalArgumentException(String.format(
-                    "Protocol '%s' does not fit the FileSystem's provider scheme (%s)",
-                    scheme, fs.provider().getScheme()));
-        }
-        return fs;
+    HttpPath(final HttpFileSystem fs, final String path, final String query, final String reference) {
+        this(fs, query, reference, getNormalizedPathBytes(path));
     }
 
     @Override
-    public FileSystem getFileSystem() {
+    public HttpFileSystem getFileSystem() {
         return fs;
     }
 
@@ -138,7 +105,8 @@ final class HttpPath implements Path {
 
     @Override
     public Path getRoot() {
-        throw new UnsupportedOperationException("Not implemented");
+        // root is a Path with only the byte array
+        return new HttpPath(fs, null, null);
     }
 
     @Override
@@ -219,7 +187,8 @@ final class HttpPath implements Path {
     @Override
     public URI toUri() {
         try {
-            return new URI(fs.provider().getScheme(), authority,
+            return new URI(getFileSystem().provider().getScheme(),
+                    getFileSystem().getAuthority(),
                     new String(normalizedPath, HttpUtils.HTTP_PATH_CHARSET),
                     query, reference);
         } catch (final URISyntaxException e) {
@@ -280,12 +249,13 @@ final class HttpPath implements Path {
 
         final HttpPath httpOther = (HttpPath) other;
         // object comparison - should be from the same provider
-        if (this.fs != httpOther.fs) {
+        if (this.getFileSystem().provider() != httpOther.getFileSystem().provider()) {
             throw new ClassCastException();
         }
 
         // first check the authority (case insensitive)
-        int comparison = this.authority.compareToIgnoreCase(httpOther.authority);
+        int comparison = getFileSystem().getAuthority()
+                .compareToIgnoreCase(httpOther.getFileSystem().getAuthority());
         if (comparison != 0) {
             return comparison;
         }
@@ -340,8 +310,7 @@ final class HttpPath implements Path {
     @Override
     public int hashCode() {
         // TODO - maybe we should cache (https://github.com/magicDGS/jsr203-http/issues/18)
-        int h = fs.hashCode();
-        h = 31 * h + authority.toLowerCase().hashCode();
+        int h = getFileSystem().hashCode();
         for (int i = 0; i < normalizedPath.length; i++) {
             h = 31 * h + (normalizedPath[i] & 0xff);
         }
@@ -354,9 +323,9 @@ final class HttpPath implements Path {
     public String toString() {
         // TODO - maybe we should cache (https://github.com/magicDGS/jsr203-http/issues/18)
         // adding scheme, authority and normalized path
-        final StringBuilder sb = new StringBuilder(fs.provider().getScheme()) // scheme
+        final StringBuilder sb = new StringBuilder(getFileSystem().provider().getScheme()) // scheme
                 .append("://")
-                .append(authority)
+                .append(getFileSystem().getAuthority()) // authority
                 .append(new String(normalizedPath, HttpUtils.HTTP_PATH_CHARSET));
         if (query != null) {
             sb.append('?').append(query);
@@ -374,7 +343,7 @@ final class HttpPath implements Path {
     private static byte[] getNormalizedPathBytes(final String path) {
         // TODO - change when we support relative Paths (https://github.com/magicDGS/jsr203-http/issues/12)
         if (!path.isEmpty() && !path.startsWith(HttpUtils.HTTP_PATH_SEPARATOR_STRING)) {
-            throw new IllegalArgumentException("Relative HTTP/S path are not supported");
+            throw new InvalidPathException(path, "Relative HTTP/S path are not supported");
         }
 
         if (HttpUtils.HTTP_PATH_SEPARATOR_STRING.equals(path) || path.isEmpty()) {
@@ -388,7 +357,7 @@ final class HttpPath implements Path {
             if (isDoubleSeparator(prevChar, c)) {
                 return getNormalizedPathBytes(path, len, i - 1);
             }
-            prevChar = checkNotNull(c);
+            prevChar = checkNotNull(path, c);
         }
         if (prevChar == HttpUtils.HTTP_PATH_SEPARATOR_CHAR) {
             return getNormalizedPathBytes(path, len, len - 1);
@@ -420,7 +389,7 @@ final class HttpPath implements Path {
                 if (isDoubleSeparator(prevChar, c)) {
                     continue;
                 }
-                prevChar = checkNotNull(c);
+                prevChar = checkNotNull(path, c);
                 os.write(c);
             }
 
@@ -435,9 +404,9 @@ final class HttpPath implements Path {
                 && prevChar == HttpUtils.HTTP_PATH_SEPARATOR_CHAR;
     }
 
-    private static char checkNotNull(char c) {
+    private static char checkNotNull(final String path, char c) {
         if (c == '\u0000') {
-            throw new IllegalArgumentException("Null character not allowed in path");
+            throw new InvalidPathException(path, "Null character not allowed in path");
         }
         return c;
     }

--- a/src/main/java/org/magicdgs/http/jsr203/HttpPath.java
+++ b/src/main/java/org/magicdgs/http/jsr203/HttpPath.java
@@ -89,7 +89,8 @@ final class HttpPath implements Path {
      * @param reference reference component for the URL (optional).
      */
     HttpPath(final HttpFileSystem fs, final String path, final String query, final String reference) {
-        this(fs, query, reference, getNormalizedPathBytes(path));
+        this(Utils.nonNull(fs, () -> "null fs"), query, reference,
+                getNormalizedPathBytes(Utils.nonNull(path, () -> "null path")));
     }
 
     @Override
@@ -187,8 +188,8 @@ final class HttpPath implements Path {
     @Override
     public URI toUri() {
         try {
-            return new URI(getFileSystem().provider().getScheme(),
-                    getFileSystem().getAuthority(),
+            return new URI(fs.provider().getScheme(),
+                    fs.getAuthority(),
                     new String(normalizedPath, HttpUtils.HTTP_PATH_CHARSET),
                     query, reference);
         } catch (final URISyntaxException e) {
@@ -249,13 +250,12 @@ final class HttpPath implements Path {
 
         final HttpPath httpOther = (HttpPath) other;
         // object comparison - should be from the same provider
-        if (this.getFileSystem().provider() != httpOther.getFileSystem().provider()) {
+        if (fs.provider() != httpOther.fs.provider()) {
             throw new ClassCastException();
         }
 
         // first check the authority (case insensitive)
-        int comparison = getFileSystem().getAuthority()
-                .compareToIgnoreCase(httpOther.getFileSystem().getAuthority());
+        int comparison = fs.getAuthority().compareToIgnoreCase(httpOther.fs.getAuthority());
         if (comparison != 0) {
             return comparison;
         }
@@ -310,7 +310,7 @@ final class HttpPath implements Path {
     @Override
     public int hashCode() {
         // TODO - maybe we should cache (https://github.com/magicDGS/jsr203-http/issues/18)
-        int h = getFileSystem().hashCode();
+        int h = fs.hashCode();
         for (int i = 0; i < normalizedPath.length; i++) {
             h = 31 * h + (normalizedPath[i] & 0xff);
         }
@@ -323,9 +323,9 @@ final class HttpPath implements Path {
     public String toString() {
         // TODO - maybe we should cache (https://github.com/magicDGS/jsr203-http/issues/18)
         // adding scheme, authority and normalized path
-        final StringBuilder sb = new StringBuilder(getFileSystem().provider().getScheme()) // scheme
+        final StringBuilder sb = new StringBuilder(fs.provider().getScheme()) // scheme
                 .append("://")
-                .append(getFileSystem().getAuthority()) // authority
+                .append(fs.getAuthority()) // authority
                 .append(new String(normalizedPath, HttpUtils.HTTP_PATH_CHARSET));
         if (query != null) {
             sb.append('?').append(query);

--- a/src/test/java/org/magicdgs/http/jsr203/HttpFileSystemUnitTest.java
+++ b/src/test/java/org/magicdgs/http/jsr203/HttpFileSystemUnitTest.java
@@ -1,15 +1,148 @@
 package org.magicdgs.http.jsr203;
 
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.nio.file.InvalidPathException;
+import java.nio.file.ProviderMismatchException;
 
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
 public class HttpFileSystemUnitTest extends BaseTest {
 
+    private static final HttpFileSystemProvider TEST_PROVIDER = new HttpFileSystemProvider();
+    private static final String TEST_AUTHORITY = "example.com";
+
+    @DataProvider
+    public Object[][] nullArgs() {
+        return new Object[][] {
+                {null, null},
+                {null, TEST_AUTHORITY},
+                {TEST_PROVIDER, null}
+        };
+    }
+
+    @Test(dataProvider = "nullArgs", expectedExceptions = NullPointerException.class)
+    public void testNullArguments(final HttpAbstractFileSystemProvider provider,
+            final String authority) {
+        new HttpFileSystem(provider, authority);
+    }
+
     @Test
-    public void testIsReadOnly() throws Exception {
-        Assert.assertTrue(new HttpFileSystem().isReadOnly());
+    public void testIsReadOnly() {
+        Assert.assertTrue(new HttpFileSystem(TEST_PROVIDER, TEST_AUTHORITY).isReadOnly());
+    }
+
+    @Test
+    public void testAlwaysOpen() {
+        final HttpFileSystem fs = new HttpFileSystem(TEST_PROVIDER, TEST_AUTHORITY);
+        Assert.assertTrue(fs.isOpen());
+        fs.close();
+        Assert.assertTrue(fs.isOpen());
+    }
+
+
+    @DataProvider
+    public Object[][] validPaths() {
+        final HttpFileSystem fs = new HttpFileSystem(TEST_PROVIDER, TEST_AUTHORITY);
+        final String file = "/file.txt";
+        final String dir = "/dir";
+        final String query = "query=hello+world";
+        final String ref = "1245";
+        final String[] empty = new String[0];
+        return new Object[][] {
+                // the root path
+                {fs, "", empty,
+                        new HttpPath(fs, "", null, null)},
+                // only paths
+                {fs, file, empty,
+                        new HttpPath(fs , file, null, null)},
+                {fs, dir + file, empty,
+                        new HttpPath(fs, dir + file, null, null)},
+                {fs, dir, new String[]{file},
+                        new HttpPath(fs, dir + file, null, null)},
+                {fs, dir + dir, new String[]{file},
+                        new HttpPath(fs, dir + dir + file, null, null)},
+                {fs, dir, new String[]{dir, file},
+                        new HttpPath(fs, dir + dir + file, null, null)},
+                // only path + query
+                {fs, dir + file + '?' + query, empty,
+                        new HttpPath(fs, dir + file, query, null)},
+                // only path + reference
+                {fs, dir + file + '#' + ref, empty,
+                        new HttpPath(fs, dir + file, null, ref)},
+                // path + query + reference
+                {fs, dir + file + '?' + query + '#' + ref, empty,
+                        new HttpPath(fs, dir + file, query, ref)},
+        };
+    }
+
+    @Test(dataProvider = "validPaths")
+    public void testGetPath(final HttpFileSystem fs, final String first, final String[] more,
+            final HttpPath expected) {
+        assertEqualsPath(fs.getPath(first, more), expected);
+    }
+
+    @DataProvider
+    public Object[][] invalidPaths() {
+        final String[] empty = new String[0];
+        return new Object[][] {
+                // relative path
+                {"directory", empty},
+                // null containing path
+                {"/directory\0null", empty},
+                // joining invalid more
+                {"/directory", new String[]{"null", "\0", "world"}}
+        };
+    }
+
+    @Test(dataProvider = "invalidPaths", expectedExceptions = InvalidPathException.class)
+    public void testInvalidGetPath(final String first, final String... more) {
+        new HttpFileSystem(TEST_PROVIDER, TEST_AUTHORITY).getPath(first, more);
+    }
+
+    @DataProvider
+    public Object[][] equalityData() {
+        final HttpFileSystem test = new HttpFileSystem(TEST_PROVIDER, TEST_AUTHORITY);
+        return new Object[][] {
+                // same object
+                {test, test, true},
+                // different objects
+                {test, new HttpFileSystem(TEST_PROVIDER, TEST_AUTHORITY), true},
+                // not equal providers
+                {test, new HttpFileSystem(new HttpsFileSystemProvider(), TEST_AUTHORITY), false},
+                // not equal authorities
+                {test, new HttpFileSystem(TEST_PROVIDER, TEST_AUTHORITY + ".org"), false}
+        };
+    }
+
+    @Test(dataProvider = "equalityData")
+    public void testEquals(final HttpFileSystem first, final HttpFileSystem second,
+            final boolean expected) {
+        Assert.assertEquals(first.equals(second), expected);
+        Assert.assertEquals(second.equals(first), expected);
+    }
+
+    @Test
+    public void testEqualsDifferentClasses() {
+        Assert.assertFalse(new HttpFileSystem(TEST_PROVIDER, TEST_AUTHORITY)
+                .equals(TEST_AUTHORITY));
+    }
+
+
+    @Test
+    public void testHashCodeSameObject() {
+        final HttpFileSystem fs = new HttpFileSystem(TEST_PROVIDER, TEST_AUTHORITY);
+        Assert.assertEquals(fs.hashCode(), fs.hashCode());
+    }
+
+    @Test
+    public void testHashCodeEqualObjects() {
+        Assert.assertEquals(
+                new HttpFileSystem(TEST_PROVIDER, TEST_AUTHORITY).hashCode(),
+                new HttpFileSystem(TEST_PROVIDER, TEST_AUTHORITY).hashCode());
     }
 }

--- a/src/test/java/org/magicdgs/http/jsr203/HttpFileSystemUnitTest.java
+++ b/src/test/java/org/magicdgs/http/jsr203/HttpFileSystemUnitTest.java
@@ -5,6 +5,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.Iterator;
 
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
@@ -42,6 +44,25 @@ public class HttpFileSystemUnitTest extends BaseTest {
         Assert.assertTrue(fs.isOpen());
     }
 
+    @DataProvider
+    public Object[][] authoritiesToTest() {
+        return new Object[][] {
+                {TEST_AUTHORITY},
+                {"example.org"},
+                {"hello.worl.net"}
+        };
+    }
+
+    @Test(dataProvider = "authoritiesToTest")
+    public void testGetRootDirectory(final String authority) {
+        final HttpFileSystem fs = new HttpFileSystem(TEST_PROVIDER, authority);
+        final Iterator<Path> root = fs.getRootDirectories().iterator();
+        assertEqualsPath(root.next(),
+                // constructing a new FileSystem to test that it generates the same independently
+                // of the instance itself
+                new HttpPath(new HttpFileSystem(TEST_PROVIDER, authority), "/", null, null));
+        Assert.assertFalse(root.hasNext());
+    }
 
     @DataProvider
     public Object[][] validPaths() {

--- a/src/test/java/org/magicdgs/http/jsr203/HttpFileSystemUnitTest.java
+++ b/src/test/java/org/magicdgs/http/jsr203/HttpFileSystemUnitTest.java
@@ -23,7 +23,7 @@ public class HttpFileSystemUnitTest extends BaseTest {
         };
     }
 
-    @Test(dataProvider = "nullArgs", expectedExceptions = NullPointerException.class)
+    @Test(dataProvider = "nullArgs", expectedExceptions = IllegalArgumentException.class)
     public void testNullArguments(final HttpAbstractFileSystemProvider provider,
             final String authority) {
         new HttpFileSystem(provider, authority);

--- a/src/test/java/org/magicdgs/http/jsr203/HttpFileSystemUnitTest.java
+++ b/src/test/java/org/magicdgs/http/jsr203/HttpFileSystemUnitTest.java
@@ -4,9 +4,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.net.URI;
 import java.nio.file.InvalidPathException;
-import java.nio.file.ProviderMismatchException;
 
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
@@ -59,14 +57,14 @@ public class HttpFileSystemUnitTest extends BaseTest {
                         new HttpPath(fs, "", null, null)},
                 // only paths
                 {fs, file, empty,
-                        new HttpPath(fs , file, null, null)},
+                        new HttpPath(fs, file, null, null)},
                 {fs, dir + file, empty,
                         new HttpPath(fs, dir + file, null, null)},
-                {fs, dir, new String[]{file},
+                {fs, dir, new String[] {file},
                         new HttpPath(fs, dir + file, null, null)},
-                {fs, dir + dir, new String[]{file},
+                {fs, dir + dir, new String[] {file},
                         new HttpPath(fs, dir + dir + file, null, null)},
-                {fs, dir, new String[]{dir, file},
+                {fs, dir, new String[] {dir, file},
                         new HttpPath(fs, dir + dir + file, null, null)},
                 // only path + query
                 {fs, dir + file + '?' + query, empty,
@@ -95,7 +93,7 @@ public class HttpFileSystemUnitTest extends BaseTest {
                 // null containing path
                 {"/directory\0null", empty},
                 // joining invalid more
-                {"/directory", new String[]{"null", "\0", "world"}}
+                {"/directory", new String[] {"null", "\0", "world"}}
         };
     }
 


### PR DESCRIPTION
Although in the current implementation the authority is handled in the `HttpPath`, the proper way is to generate a `FileSystem` for each protocol plus authority (http/s + host) to be able to work with a single base URL as the root directory.

This PR changes the simple implementation of `HttpPath` according to this new design, and modified the tests if necessary.

Closes #17 
Closes #19 
Closes #22