### PR TITLE
Remove GitHub comments from AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,10 +18,3 @@ build_script:
 # run the tests
 test_script:
 - cmd: .\gradlew.bat test
-
-# add a notification about the runs to GiHub
-notifications:
-- provider: GitHubPullRequest
-  on_build_success: true
-  on_build_failure: true
-  on_build_status_changed: true


### PR DESCRIPTION
This turn out to be too verbose. The webhook should do the work in notifying the status of the build.